### PR TITLE
Add clarifications for vf DE n78 and O2 DE n78. Remove A1 BG EARFCN 250.

### DIFF
--- a/src/BG/1.ts
+++ b/src/BG/1.ts
@@ -40,12 +40,11 @@ const data: SpectrumBlock[] = [
       startFreq: 1940,
       endFreq: 1960,
     },
-    uarfcns: [10712, 10737],
-    earfcns: [250, 275, 300],
+    uarfcns: [10737],
+    earfcns: [275, 300],
     details: [
       "LTE B1 20 MHz nationwide deployment",
-      "Indoor deployments use LTE B1 15 MHz (EARFCN 275) + UMTS B1 5 MHz",
-      "Sofia metro lines 1, 2 and 4 have LTE B1 10 MHz (EARFCN 250) + UMTS B1 10 MHz",
+      "Indoor and metro deployments use LTE B1 15 MHz (EARFCN 275) + UMTS B1 5 MHz",
     ],
   },
   {

--- a/src/BG/EARFCNs.ts
+++ b/src/BG/EARFCNs.ts
@@ -9,17 +9,10 @@ const B1: SimpleArfcnDataItem[] = [
     description: "Standard B1 deployment",
   },
   {
-    arfcn: 250,
-    bandwidth: 10,
-    operator: "A1 Bulgaria",
-    description:
-      "B1 deployment in Sofia metro lines 1, 2 and 4 (with UMTS B1 10 MHz)",
-  },
-  {
     arfcn: 275,
     bandwidth: 15,
     operator: "A1 Bulgaria",
-    description: "Indoor deployment (with UMTS B1 5 MHz)",
+    description: "Indoor and metro deployment (with UMTS B1 5 MHz)",
   },
   {
     arfcn: 300,

--- a/src/DE/78.ts
+++ b/src/DE/78.ts
@@ -8,6 +8,7 @@ const data: SpectrumBlock[] = [
     endFreq: 3490,
     type: "tdd",
     nrarfcns: [628800, 629952, 631968],
+    details: "3400-3410 MHz only for indoor use",
   },
   {
     owner: "1&1",

--- a/src/DE/NRARFCNs.ts
+++ b/src/DE/NRARFCNs.ts
@@ -13,21 +13,21 @@ const n1: SimpleArfcnDataItem[] = [
 const n78: SimpleArfcnDataItem[] = [
   {
     arfcn: 628800,
-    bandwidth: 90,
+    bandwidth: [60, 80, 90],
     operator: "Vodafone DE",
-    description: "n78 deployment",
+    description: "Ericsson n78 deployment",
   },
   {
     arfcn: 629952,
-    bandwidth: 90,
+    bandwidth: [80, 90],
     operator: "Vodafone DE",
-    description: "n78 deployment",
+    description: "Huawei n78 deployment",
   },
   {
     arfcn: 631968,
-    bandwidth: 90,
+    bandwidth: [80, 90],
     operator: "Vodafone DE",
-    description: "n78 deployment",
+    description: "Huawei n78 deployment",
   },
   {
     arfcn: 633312,
@@ -37,7 +37,7 @@ const n78: SimpleArfcnDataItem[] = [
   },
   {
     arfcn: 638304,
-    bandwidth: 70,
+    bandwidth: [60, 70],
     operator: "O2 DE",
     description: "n78 deployment",
   },


### PR DESCRIPTION
vf DE mostly use n78 80 MHz since 3400-3410 MHz is limited to indoor use only.
vf DE sometimes has n78 60 MHz on old Ericsson sites.
O2 DE sometimes has n78 60 MHz (although I'm not sure about this).

A1 BG stopped using EARFCN 250 in the Sofia metro this week.