### PR TITLE
feat(BG): add A1 B20 EARFCN and n28 NR-ARFCN; feat(RS): change Yettel SRB B1 EARFCN

### DIFF
--- a/src/BG/20.ts
+++ b/src/BG/20.ts
@@ -12,10 +12,11 @@ const data: SpectrumBlock[] = [
       startFreq: 832,
       endFreq: 842,
     },
+    earfcns: [6200],
     details: ["Restricted in some areas until the end of 2025"],
     sourceInfo: {
       type: "url",
-      url: "https://crc.bg/files/%D0%92%D0%9E%D0%9F/01-1_%D0%90%201%20%D0%91%D0%AA%D0%9B%D0%93%D0%90%D0%A0%D0%98%D0%AF%20%D0%95%D0%90%D0%94.-%D0%98%D0%97%D0%94%D0%90%D0%92%D0%90%D0%9D%D0%95%20%D0%9D%D0%90%20%D0%A0%D0%90%D0%97%D0%A0%D0%95%D0%A8%D0%95%D0%9D%D0%98%D0%95%20%D0%92%20%D0%9E%D0%91%D0%A5%D0%92%D0%90%D0%A2%D0%98%20700%20%D0%98%20800-%D0%BD%D0%BE%D0%B5%D0%BC%D0%B2%D1%80%D0%B8%202023%20(2).pdf",
+      url: "https://crc.bg/files/ВОП/01-1_А%201%20БЪЛГАРИЯ%20ЕАД.-ИЗДАВАНЕ%20НА%20РАЗРЕШЕНИЕ%20В%20ОБХВАТИ%20700%20И%20800-ноември%202023%20(2).pdf",
     },
   },
   {
@@ -32,7 +33,7 @@ const data: SpectrumBlock[] = [
     details: ["Restricted in some areas until the end of 2025"],
     sourceInfo: {
       type: "url",
-      url: "https://crc.bg/files/%D0%92%D0%9E%D0%9F/01-2_%D0%92%D0%98%D0%92%D0%90%D0%9A%D0%9E%D0%9C-%D0%98%D0%97%D0%94%D0%90%D0%92%D0%90%D0%9D%D0%95%20%D0%9D%D0%90%20%D0%A0%D0%90%D0%97%D0%A0%D0%95%D0%A8%D0%95%D0%9D%D0%98%D0%95%20%D0%92%20%D0%9E%D0%91%D0%A5%D0%92%D0%90%D0%A2%D0%98%20700%20%D0%98%20800-%D0%BD%D0%BE%D0%B5%D0%BC%D0%B2%D1%80%D0%B8%202023%20(2).pdf",
+      url: "https://crc.bg/files/ВОП/01-2_ВИВАКОМ-ИЗДАВАНЕ%20НА%20РАЗРЕШЕНИЕ%20В%20ОБХВАТИ%20700%20И%20800-ноември%202023%20(2).pdf",
     },
   },
   {
@@ -50,7 +51,7 @@ const data: SpectrumBlock[] = [
     details: ["Restricted in some areas until the end of 2025"],
     sourceInfo: {
       type: "url",
-      url: "https://crc.bg/files/%D0%92%D0%9E%D0%9F/01-3_%D0%99%D0%95%D0%A2%D0%A2%D0%95%D0%9B%20%20%D0%98%D0%97%D0%94%D0%90%D0%92%D0%90%D0%9D%D0%95%20%D0%9D%D0%90%20%D0%A0%D0%90%D0%97%D0%A0%D0%95%D0%A8%D0%95%D0%9D%D0%98%D0%95%20%D0%92%20%D0%9E%D0%91%D0%A5%D0%92%D0%90%D0%A2%D0%98%20700%20%D0%98%20800-%D0%BD%D0%BE%D0%B5%D0%BC%D0%B2%D1%80%D0%B8%202023%20(1).pdf",
+      url: "https://crc.bg/files/ВОП/01-3_ЙЕТТЕЛ%20%20ИЗДАВАНЕ%20НА%20РАЗРЕШЕНИЕ%20В%20ОБХВАТИ%20700%20И%20800-ноември%202023%20(1).pdf",
     },
   },
 ];

--- a/src/BG/28.ts
+++ b/src/BG/28.ts
@@ -12,10 +12,11 @@ const data: SpectrumBlock[] = [
       startFreq: 703,
       endFreq: 713,
     },
-    details: ["Restricted in some areas until the end of 2025"],
+    nrarfcns: [152690],
+    details: ["NR only", "Restricted in some areas until the end of 2025"],
     sourceInfo: {
       type: "url",
-      url: "https://crc.bg/files/%D0%92%D0%9E%D0%9F/01-1_%D0%90%201%20%D0%91%D0%AA%D0%9B%D0%93%D0%90%D0%A0%D0%98%D0%AF%20%D0%95%D0%90%D0%94.-%D0%98%D0%97%D0%94%D0%90%D0%92%D0%90%D0%9D%D0%95%20%D0%9D%D0%90%20%D0%A0%D0%90%D0%97%D0%A0%D0%95%D0%A8%D0%95%D0%9D%D0%98%D0%95%20%D0%92%20%D0%9E%D0%91%D0%A5%D0%92%D0%90%D0%A2%D0%98%20700%20%D0%98%20800-%D0%BD%D0%BE%D0%B5%D0%BC%D0%B2%D1%80%D0%B8%202023%20(2).pdf",
+      url: "https://crc.bg/files/ВОП/01-1_А%201%20БЪЛГАРИЯ%20ЕАД.-ИЗДАВАНЕ%20НА%20РАЗРЕШЕНИЕ%20В%20ОБХВАТИ%20700%20И%20800-ноември%202023%20(2).pdf",
     },
   },
   {
@@ -32,7 +33,7 @@ const data: SpectrumBlock[] = [
     details: ["Restricted in some areas until the end of 2025"],
     sourceInfo: {
       type: "url",
-      url: "https://crc.bg/files/%D0%92%D0%9E%D0%9F/01-2_%D0%92%D0%98%D0%92%D0%90%D0%9A%D0%9E%D0%9C-%D0%98%D0%97%D0%94%D0%90%D0%92%D0%90%D0%9D%D0%95%20%D0%9D%D0%90%20%D0%A0%D0%90%D0%97%D0%A0%D0%95%D0%A8%D0%95%D0%9D%D0%98%D0%95%20%D0%92%20%D0%9E%D0%91%D0%A5%D0%92%D0%90%D0%A2%D0%98%20700%20%D0%98%20800-%D0%BD%D0%BE%D0%B5%D0%BC%D0%B2%D1%80%D0%B8%202023%20(2).pdf",
+      url: "https://crc.bg/files/ВОП/01-2_ВИВАКОМ-ИЗДАВАНЕ%20НА%20РАЗРЕШЕНИЕ%20В%20ОБХВАТИ%20700%20И%20800-ноември%202023%20(2).pdf",
     },
   },
   {
@@ -50,7 +51,7 @@ const data: SpectrumBlock[] = [
     details: ["NR only", "Restricted in some areas until the end of 2025"],
     sourceInfo: {
       type: "url",
-      url: "https://crc.bg/files/%D0%92%D0%9E%D0%9F/01-3_%D0%99%D0%95%D0%A2%D0%A2%D0%95%D0%9B%20%20%D0%98%D0%97%D0%94%D0%90%D0%92%D0%90%D0%9D%D0%95%20%D0%9D%D0%90%20%D0%A0%D0%90%D0%97%D0%A0%D0%95%D0%A8%D0%95%D0%9D%D0%98%D0%95%20%D0%92%20%D0%9E%D0%91%D0%A5%D0%92%D0%90%D0%A2%D0%98%20700%20%D0%98%20800-%D0%BD%D0%BE%D0%B5%D0%BC%D0%B2%D1%80%D0%B8%202023%20(1).pdf",
+      url: "https://crc.bg/files/ВОП/01-3_ЙЕТТЕЛ%20%20ИЗДАВАНЕ%20НА%20РАЗРЕШЕНИЕ%20В%20ОБХВАТИ%20700%20И%20800-ноември%202023%20(1).pdf",
     },
   },
 ];

--- a/src/BG/EARFCNs.ts
+++ b/src/BG/EARFCNs.ts
@@ -112,6 +112,12 @@ const B8: SimpleArfcnDataItem[] = [
 
 const B20: SimpleArfcnDataItem[] = [
   {
+    arfcn: 6200,
+    bandwidth: 10,
+    operator: "A1 Bulgaria",
+    description: "Standard B20 deployment",
+  },
+  {
     arfcn: 6400,
     bandwidth: 10,
     operator: "Yettel Bulgaria",

--- a/src/BG/NRARFCNs.ts
+++ b/src/BG/NRARFCNs.ts
@@ -21,6 +21,12 @@ const n7: SimpleArfcnDataItem[] = [
 
 const n28: SimpleArfcnDataItem[] = [
   {
+    arfcn: 152690,
+    bandwidth: 10,
+    operator: "A1 Bulgaria",
+    description: "Standard n28 deployment",
+  },
+  {
     arfcn: 156510,
     bandwidth: 10,
     operator: "Yettel Bulgaria",

--- a/src/RS/1.ts
+++ b/src/RS/1.ts
@@ -2,8 +2,7 @@ import type { SpectrumBlock } from "../@types";
 
 const data: SpectrumBlock[] = [
   {
-    owner: "Yettel",
-    ownerLongName: "Yettel Srbija",
+    owner: "Unallocated",
     startFreq: 2110,
     endFreq: 2125,
     type: "fddDown",
@@ -89,32 +88,14 @@ const data: SpectrumBlock[] = [
     owner: "Yettel",
     ownerLongName: "Yettel Srbija",
     startFreq: 2155,
-    endFreq: 2160,
-    type: "fddDown",
-    pairedWith: {
-      type: "fddUp",
-      startFreq: 1965,
-      endFreq: 1970,
-    },
-    uarfcns: [10788],
-    details: ["Spectrum for temporary use"],
-    sourceInfo: {
-      type: "url",
-      url: "https://www.ratel.rs/en/page/public-communications-networks",
-    },
-  },
-  {
-    owner: "Yettel",
-    ownerLongName: "Yettel Srbija",
-    startFreq: 2160,
     endFreq: 2170,
     type: "fddDown",
     pairedWith: {
       type: "fddUp",
-      startFreq: 1970,
+      startFreq: 1965,
       endFreq: 1980,
     },
-    earfcns: [550],
+    earfcns: [525],
     details: ["Spectrum for temporary use"],
     sourceInfo: {
       type: "url",

--- a/src/RS/EARFCNs.ts
+++ b/src/RS/EARFCNs.ts
@@ -15,8 +15,8 @@ const B1: SimpleArfcnDataItem[] = [
     description: "Standard B1 deployment",
   },
   {
-    arfcn: 550,
-    bandwidth: 10,
+    arfcn: 525,
+    bandwidth: 15,
     operator: "Yettel Srbija",
     description: "Standard B1 deployment",
   },


### PR DESCRIPTION
I added A1 BG's new B20 EARFCN and A1 BG's new n28 NR-ARFCN. They are currently available only on 1 site in Sofia, but I expect that they will soon be more widely deployed.
I fixed the long and ugly URLs with the same links but in Cyrillic. 