### PR TITLE
fix: BG B7 spectrum were swapped previously

### DIFF
--- a/src/BG/7.ts
+++ b/src/BG/7.ts
@@ -26,8 +26,8 @@ const data: SpectrumBlock[] = [
     earfcns: [2950],
   },
   {
-    owner: "Yettel",
-    ownerLongName: "Yettel Bulgaria",
+    owner: "Vivacom",
+    ownerLongName: "Vivacom Bulgaria",
     startFreq: 2650,
     endFreq: 2670,
     type: "fddDown",
@@ -37,12 +37,10 @@ const data: SpectrumBlock[] = [
       endFreq: 2550,
     },
     earfcns: [3150],
-    nrarfcns: [534884],
-    details: ["LTE B7 20 MHz, n7 DSS in some urban areas"],
   },
   {
-    owner: "Vivacom",
-    ownerLongName: "Vivacom Bulgaria",
+    owner: "Yettel",
+    ownerLongName: "Yettel Bulgaria",
     startFreq: 2670,
     endFreq: 2690,
     type: "fddDown",
@@ -52,6 +50,8 @@ const data: SpectrumBlock[] = [
       endFreq: 2570,
     },
     earfcns: [3350],
+    nrarfcns: [534884],
+    details: ["LTE B7 20 MHz, n7 DSS in some urban areas"],
   },
 ];
 

--- a/src/BG/EARFCNs.ts
+++ b/src/BG/EARFCNs.ts
@@ -71,13 +71,13 @@ const B7: SimpleArfcnDataItem[] = [
   {
     arfcn: 3150,
     bandwidth: 20,
-    operator: "Yettel Bulgaria",
+    operator: "Vivacom",
     description: "Standard B7 deployment",
   },
   {
     arfcn: 3350,
     bandwidth: 20,
-    operator: "Vivacom",
+    operator: "Yettel Bulgaria",
     description: "Standard B7 deployment",
   },
 ];


### PR DESCRIPTION
I accidentally swapped Yettel and Vivacom's B7 spectrum when I initially added them.